### PR TITLE
docs: update README to reflect actual exported components and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,12 +422,15 @@ This affects:
 
 ## Available Exports
 
-### Component
-- `JsonSchemaBuilder` - Main builder component (controlled)
+### Components
+- `JsonSchemaBuilder` – Main controlled JSON schema builder component
+- `PropertyEditDialog` – Standalone dialog for editing a single schema property
 
 ### Types
-- `JsonSchemaBuilderProps` - Props for the main component
-- `TypeLabels` - Type for customizing property type labels
+- `JsonSchemaBuilderProps` – Props for the main builder component
+- `PropertyData` – Type definition for a schema property
+- `TypeLabels` – Type for customizing property type labels
+
 
 ## Advanced Usage
 


### PR DESCRIPTION
## Summary
Updates the README to accurately document the library’s public exports.

## Changes
- Documented `PropertyEditDialog` as an exported component
- Added `PropertyData` to the list of exported types
- Aligned README with actual usage examples

Fixes #ISSUE_NUMBER